### PR TITLE
Add jython

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,9 @@ dependencies {
 
 	// PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
 	// You may need to force-disable transitiveness on them.
+	
+	implementation 'org.python:jython-slim:2.7.2'
+
 }
 
 processResources {


### PR DESCRIPTION
This is good because python is turing complete! It can interpret brainfricc so it msut be. i kno this is true since I read it in my national geographic magazine 3 years ago

pls merge kthx

also
python is turing complete so it can parse any config format
so by adding jython we add every potential config format!!!!