### PR TITLE
Add reflective event handlers and a remove block event for Event API v4

### DIFF
--- a/src/main/java/io/github/fabriccommunity/everything/api/event/v4/EventHandler.java
+++ b/src/main/java/io/github/fabriccommunity/everything/api/event/v4/EventHandler.java
@@ -20,13 +20,15 @@ package io.github.fabriccommunity.everything.api.event.v4;
 import com.mojang.datafixers.util.Unit;
 import io.github.fabriccommunity.everything.api.functional.IO;
 
+import java.util.EventListener;
+
 /**
  * An event handler.
  *
  * @param <A> the event type
  */
 @FunctionalInterface
-public interface EventHandler<A> {
+public interface EventHandler<A> extends EventListener {
     /**
      * Handles the event.
      *

--- a/src/main/java/io/github/fabriccommunity/everything/api/event/v4/EventHandler.java
+++ b/src/main/java/io/github/fabriccommunity/everything/api/event/v4/EventHandler.java
@@ -19,8 +19,17 @@ package io.github.fabriccommunity.everything.api.event.v4;
 
 import com.mojang.datafixers.util.Unit;
 import io.github.fabriccommunity.everything.api.functional.IO;
+import io.github.fabriccommunity.everything.api.functional.Iterables;
+import io.github.fabriccommunity.everything.api.functional.ThrowingRunnable;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 import java.util.EventListener;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * An event handler.
@@ -36,4 +45,70 @@ public interface EventHandler<A> extends EventListener {
      * @return the IO operation
      */
     IO<Unit> handle(A event);
+
+    @SuppressWarnings("unchecked")
+    static <A> EventHandler<A> composite(final Iterable<? extends EventHandler<? super A>> handlers) {
+        return (EventHandler<A>) Iterables.<EventHandler<? super A>>reduce(handlers, (first, second) -> (A event) -> first.handle(event).andThen(second.handle(event)));
+    }
+
+    static <A> EventHandler<A> reflective(final Object handler, final Class<A> eventClass) {
+        Objects.requireNonNull(handler, "the handler is null");
+        Objects.requireNonNull(eventClass, "the event type is null");
+
+        return ReflectiveHandlerImpl.create(handler.getClass(), handler, eventClass);
+    }
+
+    static <A> EventHandler<A> reflective(final Class<?> handlerClass, final Class<A> eventClass) {
+        Objects.requireNonNull(handlerClass, "the handler type is null");
+        Objects.requireNonNull(eventClass, "the event type is null");
+
+        return ReflectiveHandlerImpl.create(handlerClass, null, eventClass);
+    }
+}
+
+final class ReflectiveHandlerImpl {
+    private ReflectiveHandlerImpl() {}
+
+    static <A> EventHandler<A> create(final Class<?> handlerClass, final Object handler, final Class<A> eventClass) {
+        final boolean staticMode = handler == null;
+        final List<EventHandler<A>> handlers = new ArrayList<>();
+        final MethodHandles.Lookup lookup = MethodHandles.lookup();
+
+        for (Method method : handlerClass.getDeclaredMethods()) {
+            final HandleEvent annotation = method.getAnnotation(HandleEvent.class);
+            if (annotation == null) continue;
+
+            final boolean isStatic = Modifier.isStatic(method.getModifiers());
+            if (isStatic != staticMode) continue;
+
+            if (method.getParameterCount() != 1) {
+                throw new IllegalArgumentException("Handler method " + method.getName() + " has the wrong amount of parameters! Excepted: 1, found: " + method.getParameterCount());
+            }
+
+            final boolean isValidType = method.getParameterTypes()[0].isAssignableFrom(eventClass);
+            if (!isValidType) continue;
+
+            final Class<?> returnType = method.getReturnType();
+            if (returnType != void.class && returnType != IO.class) {
+                throw new IllegalArgumentException("Handler method " + method.getName() + " needs to return void or IO instead of " + returnType + "!");
+            }
+
+            method.setAccessible(true);
+            try {
+                MethodHandle handle = lookup.unreflect(method);
+                if (!staticMode) handle = handle.bindTo(handler);
+                final MethodHandle effectivelyFinalHandle = handle;
+                handlers.add(event -> IO.of((ThrowingRunnable) () -> {
+                    final Object result = effectivelyFinalHandle.invoke(event);
+                    if (result instanceof IO<?>) {
+                        ((IO<?>) result).execute();
+                    }
+                }));
+            } catch (IllegalAccessException e) {
+                throw new IllegalStateException("Failed to convert Method instance to a handler", e);
+            }
+        }
+
+        return EventHandler.composite(handlers);
+    }
 }

--- a/src/main/java/io/github/fabriccommunity/everything/api/event/v4/HandleEvent.java
+++ b/src/main/java/io/github/fabriccommunity/everything/api/event/v4/HandleEvent.java
@@ -1,0 +1,28 @@
+/*
+ *     Copyright (C) 2020 Fabric Community
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.fabriccommunity.everything.api.event.v4;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface HandleEvent {
+}

--- a/src/main/java/io/github/fabriccommunity/everything/api/event/v4/events/RemoveBlockEvent.java
+++ b/src/main/java/io/github/fabriccommunity/everything/api/event/v4/events/RemoveBlockEvent.java
@@ -1,0 +1,63 @@
+/*
+ *     Copyright (C) 2020 Fabric Community
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.fabriccommunity.everything.api.event.v4.events;
+
+import io.github.fabriccommunity.everything.api.event.v4.AbstractVetoableEvent;
+import io.github.fabriccommunity.everything.api.event.v4.EventManager;
+import net.minecraft.block.BlockState;
+import net.minecraft.fluid.FluidState;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+public final class RemoveBlockEvent extends AbstractVetoableEvent {
+    public static final EventManager<RemoveBlockEvent> MANAGER = EventManager.create();
+
+    private final World world;
+    private final BlockPos pos;
+    private final boolean move;
+    private final FluidState fluidState;
+    private final BlockState blockState;
+
+    public RemoveBlockEvent(final World world, final BlockPos pos, final boolean move, final FluidState fluidState) {
+        this.world = world;
+        this.pos = pos;
+        this.move = move;
+        this.fluidState = fluidState;
+        this.blockState = world.getBlockState(pos);
+    }
+
+    public World getWorld() {
+        return world;
+    }
+
+    public BlockPos getPos() {
+        return pos;
+    }
+
+    public boolean isMove() {
+        return move;
+    }
+
+    public FluidState getFluidState() {
+        return fluidState;
+    }
+
+    public BlockState getBlockState() {
+        return blockState;
+    }
+}

--- a/src/main/java/io/github/fabriccommunity/everything/api/functional/Iterables.java
+++ b/src/main/java/io/github/fabriccommunity/everything/api/functional/Iterables.java
@@ -1,0 +1,32 @@
+package io.github.fabriccommunity.everything.api.functional;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.function.BiFunction;
+
+public final class Iterables {
+    private Iterables() {}
+
+    public static <A> A reduce(final Iterable<? extends A> source, final BiFunction<? super A, ? super A, ? extends A> func) {
+        final Iterator<? extends A> iter = source.iterator();
+        if (!iter.hasNext()) throw new NoSuchElementException("source is empty!");
+
+        A current = iter.next();
+
+        while (iter.hasNext()) {
+            current = func.apply(current, iter.next());
+        }
+
+        return current;
+    }
+
+    public static <A, B> B fold(final Iterable<? extends A> source, final B seed, final BiFunction<? super B, ? super A, ? extends B> func) {
+        B current = seed;
+
+        for (A a : source) {
+            current = func.apply(current, a);
+        }
+
+        return current;
+    }
+}

--- a/src/main/java/io/github/fabriccommunity/everything/mixin/implementation/event/v4/ServerPlayerEntityMixin.java
+++ b/src/main/java/io/github/fabriccommunity/everything/mixin/implementation/event/v4/ServerPlayerEntityMixin.java
@@ -15,7 +15,7 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package io.github.fabriccommunity.everything.mixin.general;
+package io.github.fabriccommunity.everything.mixin.implementation.event.v4;
 
 import com.mojang.authlib.GameProfile;
 import io.github.fabriccommunity.everything.api.elegant.scalar.ScalarOf;

--- a/src/main/java/io/github/fabriccommunity/everything/mixin/implementation/event/v4/WorldMixin.java
+++ b/src/main/java/io/github/fabriccommunity/everything/mixin/implementation/event/v4/WorldMixin.java
@@ -1,0 +1,41 @@
+/*
+ *     Copyright (C) 2020 Fabric Community
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.fabriccommunity.everything.mixin.implementation.event.v4;
+
+import io.github.fabriccommunity.everything.api.elegant.scalar.ScalarOf;
+import io.github.fabriccommunity.everything.api.event.v4.events.RemoveBlockEvent;
+import io.github.fabriccommunity.everything.api.functional.IO;
+import net.minecraft.fluid.FluidState;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IWorld;
+import net.minecraft.world.World;
+import org.cactoos.scalar.Ternary;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+@Mixin(World.class)
+abstract class WorldMixin implements IWorld {
+    @Inject(method = "removeBlock", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/world/World;getFluidState(Lnet/minecraft/util/math/BlockPos;)Lnet/minecraft/fluid/FluidState;"), cancellable = true, locals = LocalCapture.CAPTURE_FAILHARD)
+    private void onRemoveBlock(BlockPos pos, boolean move, CallbackInfoReturnable<Boolean> info, FluidState fluidState) {
+        final RemoveBlockEvent event = new RemoveBlockEvent((World) (Object) this, pos, move, fluidState);
+        IO.executeUnsafe(RemoveBlockEvent.MANAGER.execute(event).andThen(IO.of(new Ternary<>(new ScalarOf<>(event.isVetoed()), new ScalarOf<>(IO.of(() -> info.setReturnValue(false))), new ScalarOf<>(IO.empty())))));
+    }
+}

--- a/src/main/java/io/github/fabriccommunity/everything/mixin/implementation/event/v4/client/ClientPlayerInteractionManagerMixin.java
+++ b/src/main/java/io/github/fabriccommunity/everything/mixin/implementation/event/v4/client/ClientPlayerInteractionManagerMixin.java
@@ -1,0 +1,26 @@
+package io.github.fabriccommunity.everything.mixin.implementation.event.v4.client;
+
+import com.mojang.datafixers.util.Unit;
+import io.github.fabriccommunity.everything.api.elegant.scalar.ScalarOf;
+import io.github.fabriccommunity.everything.api.event.v4.events.RemoveBlockEvent;
+import io.github.fabriccommunity.everything.api.functional.IO;
+import net.minecraft.block.BlockState;
+import net.minecraft.client.network.ClientPlayerInteractionManager;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.cactoos.scalar.Ternary;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+@Mixin(ClientPlayerInteractionManager.class)
+abstract class ClientPlayerInteractionManagerMixin {
+    @Inject(method = "breakBlock", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/Block;onBreak(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;Lnet/minecraft/entity/player/PlayerEntity;)V"), cancellable = true, locals = LocalCapture.CAPTURE_FAILHARD)
+    private void onBreakBlock(final BlockPos pos, final CallbackInfoReturnable<Boolean> info, final World world, final BlockState state) {
+        final RemoveBlockEvent event = new RemoveBlockEvent(world, pos, false, world.getFluidState(pos));
+        IO.executeUnsafe(RemoveBlockEvent.MANAGER.execute(event).andThen(IO.of(new Ternary<>(new ScalarOf<>(event.isVetoed()), new ScalarOf<>(IO.of(() -> info.setReturnValue(false))), new ScalarOf<>(IO.empty())))));
+    }
+}

--- a/src/main/resources/everything.mixins.json
+++ b/src/main/resources/everything.mixins.json
@@ -11,17 +11,19 @@
     "general.ContinentLayerMixin",
     "general.VanillaLayeredBiomeSourceMixin",
     "general.SetBaseBiomesLayerMixin",
-    "general.ServerPlayerEntityMixin",
     "implementation.event.v3.BlockEventsImpl",
     "implementation.event.v3.PlayerManagerImpl",
     "implementation.event.v3.ServerMainImpl",
     "implementation.event.v3.ServerPlayNetworkHandlerImpl",
+    "implementation.event.v4.ServerPlayerEntityMixin",
+    "implementation.event.v4.WorldMixin",
     "implementation.level.SetBlockEventMixin"
   ],
   "client": [
     "implementation.event.v3.ClientMainImpl",
     "implementation.event.v3.MinecraftClientImpl",
     "implementation.event.v3.ClientPlayNetworkHandlerImpl",
+    "implementation.event.v4.client.ClientPlayerInteractionManagerMixin",
     "implementation.render.ItemRendererRegistryImpl",
     "implementation.model.BlockModelInjectionRegistryImpl",
     "implementation.model.ItemModelInjectionRegistryImpl"


### PR DESCRIPTION
You can now do:
```java
public class MyMod implements FunctionalModInitializer {
    @Override
    public IO<Unit> onInitialize() {
        return RemoveBlockEvent.MANAGER.register(EventHandler.reflective(this, RemoveBlockEvent.class));
    }

    @HandleEvent
    private IO<Unit> preventBlockBreaking(final RemoveBlockEvent event) {
        return event.veto();
    }
}
```