### PR TITLE
Gives programmers more freedom when adding new ores

### DIFF
--- a/src/main/java/io/github/fabriccommunity/everything/api/TargetViolatorHelper.java
+++ b/src/main/java/io/github/fabriccommunity/everything/api/TargetViolatorHelper.java
@@ -1,0 +1,59 @@
+package io.github.fabriccommunity.everything.api;
+
+import java.util.Arrays;
+import java.util.function.Predicate;
+
+import com.google.common.collect.Maps;
+
+import io.github.fabriccommunity.everything.mixin.TargetViolator;
+import net.minecraft.block.BlockState;
+import net.minecraft.world.gen.feature.OreFeatureConfig.Target;
+
+public final class TargetViolatorHelper {
+
+    /**
+     * allows user to break Target.*
+     * @param target
+     */
+    public static final void register(Target target)
+    {
+        Target[] targets = TargetViolator.getValues();
+        targets = Arrays.copyOf(targets, targets.length+1);
+        targets[targets.length-1] = target;
+        TargetViolator.setValues(targets);
+        try
+        {
+            TargetViolator.getNameMap().put(target.getName(), target);
+        }
+        catch(Throwable t)
+        {
+            TargetViolator.setNameMap(Maps.newHashMap(TargetViolator.getNameMap()));
+            TargetViolator.getNameMap().put(target.getName(), target);
+        }
+    }
+    /**
+     * prevent user from breaking Target.values()
+     * @param enumName
+     * @param targetName
+     * @param pred
+     * @return
+     */
+    public static final Target register(String enumName,String targetName, Predicate<BlockState> pred)
+    {
+        Target target = TargetViolator.newTarget(enumName, TargetViolator.getValues().length-1, targetName, pred);
+        Target[] targets = TargetViolator.getValues();
+        targets = Arrays.copyOf(targets, targets.length+1);
+        targets[targets.length-1] = target;
+        TargetViolator.setValues(targets);
+        try
+        {
+            TargetViolator.getNameMap().put(target.getName(), target);
+        }
+        catch(Throwable t)
+        {
+            TargetViolator.setNameMap(Maps.newHashMap(TargetViolator.getNameMap()));
+            TargetViolator.getNameMap().put(target.getName(), target);
+        }
+        return target;
+    }
+}

--- a/src/main/java/io/github/fabriccommunity/everything/mixin/TargetViolator.java
+++ b/src/main/java/io/github/fabriccommunity/everything/mixin/TargetViolator.java
@@ -1,0 +1,45 @@
+package io.github.fabriccommunity.everything.mixin;
+
+import java.util.Map;
+import java.util.function.Predicate;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.world.gen.feature.OreFeatureConfig;
+import net.minecraft.world.gen.feature.OreFeatureConfig.Target;
+
+@Mixin(OreFeatureConfig.Target.class)
+public interface TargetViolator {
+    @Invoker("<init>")
+    public static Target newTarget(String enuName,int enumIndex, String featureName, Predicate<BlockState> predicate)
+    {
+        throw new IllegalStateException("Where'd my accessor go");
+    }
+    /**
+     * Synthetic field holding Enum#values() value
+     */
+    @Accessor("field_13729")
+    public static Target[] getValues()
+    {
+        throw new IllegalStateException("Where'd my accessor go");
+    }
+    @Accessor("field_13729")
+    public static void setValues(Target[] targets)
+    {
+        throw new IllegalStateException("Where'd my accessor go");
+    }
+    @Accessor("nameMap")
+    public static Map<String, Target> getNameMap()
+    {
+        throw new IllegalStateException("Where'd my accessor go");
+    }
+    @Accessor("nameMap")
+    public static void setNameMap(Map<String, Target> targets)
+    {
+        throw new IllegalStateException("Where'd my accessor go");
+    }
+
+}

--- a/src/main/resources/everything.mixins.json
+++ b/src/main/resources/everything.mixins.json
@@ -17,7 +17,8 @@
     "implementation.event.v3.ServerPlayNetworkHandlerImpl",
     "implementation.event.v4.ServerPlayerEntityMixin",
     "implementation.event.v4.WorldMixin",
-    "implementation.level.SetBlockEventMixin"
+    "implementation.level.SetBlockEventMixin",
+    "TargetViolator"
   ],
   "client": [
     "implementation.event.v3.ClientMainImpl",

--- a/src/main/resources/widenme.baby
+++ b/src/main/resources/widenme.baby
@@ -1,6 +1,4 @@
-accessWidener	v1  named
-mutable field net/minecraft/client/MinecraftClient currentFps I
-accessible field net/minecraft/client/MinecraftClient currentFps I
+accessWidener	v1	named
 mutable	field	net/minecraft/world/gen/feature/OreFeatureConfig	target	Lnet/minecraft/world/gen/feature/OreFeatureConfig$Target;
 mutable	field	net/minecraft/world/gen/feature/OreFeatureConfig	size	I
 mutable	field	net/minecraft/world/gen/feature/OreFeatureConfig	state	Lnet/minecraft/block/BlockState;


### PR DESCRIPTION
Allows programmers to create new OreFeatureConfig.Target's at will. This was fully tested and does work. Who says you can't add new Enums without 🍫 ?