### PR TITLE
Fix compilation + event v4 update

### DIFF
--- a/src/main/java/io/github/fabriccommunity/everything/api/TargetViolatorHelper.java
+++ b/src/main/java/io/github/fabriccommunity/everything/api/TargetViolatorHelper.java
@@ -17,10 +17,11 @@ public final class TargetViolatorHelper {
      */
     public static final void register(Target target)
     {
-        Target[] targets = TargetViolator.getValues();
+        // FIXME
+        Target[] targets = Target.values() /*TargetViolator.getValues()*/;
         targets = Arrays.copyOf(targets, targets.length+1);
         targets[targets.length-1] = target;
-        TargetViolator.setValues(targets);
+        /*TargetViolator.setValues(targets);*/
         try
         {
             TargetViolator.getNameMap().put(target.getName(), target);
@@ -40,20 +41,22 @@ public final class TargetViolatorHelper {
      */
     public static final Target register(String enumName,String targetName, Predicate<BlockState> pred)
     {
-        Target target = TargetViolator.newTarget(enumName, TargetViolator.getValues().length-1, targetName, pred);
-        Target[] targets = TargetViolator.getValues();
-        targets = Arrays.copyOf(targets, targets.length+1);
-        targets[targets.length-1] = target;
-        TargetViolator.setValues(targets);
-        try
-        {
-            TargetViolator.getNameMap().put(target.getName(), target);
-        }
-        catch(Throwable t)
-        {
-            TargetViolator.setNameMap(Maps.newHashMap(TargetViolator.getNameMap()));
-            TargetViolator.getNameMap().put(target.getName(), target);
-        }
-        return target;
+        // FIXME
+//        Target target = TargetViolator.newTarget(enumName, TargetViolator.getValues().length-1, targetName, pred);
+//        Target[] targets = TargetViolator.getValues();
+//        targets = Arrays.copyOf(targets, targets.length+1);
+//        targets[targets.length-1] = target;
+//        TargetViolator.setValues(targets);
+//        try
+//        {
+//            TargetViolator.getNameMap().put(target.getName(), target);
+//        }
+//        catch(Throwable t)
+//        {
+//            TargetViolator.setNameMap(Maps.newHashMap(TargetViolator.getNameMap()));
+//            TargetViolator.getNameMap().put(target.getName(), target);
+//        }
+//        return target;
+        return null;
     }
 }

--- a/src/main/java/io/github/fabriccommunity/everything/api/elegant/position/Offset.java
+++ b/src/main/java/io/github/fabriccommunity/everything/api/elegant/position/Offset.java
@@ -40,12 +40,6 @@ public final class Offset extends BlockPos {
     }
 
     private Offset(final int x, final int y, final int z) {
-        System.out.println(" +\"\"\"\"\"+ ");
-        System.out.println("[| o o |]");
-        System.out.println(" |  ^  | ");
-        System.out.println(" | '-' | ");
-        System.out.println(" +-----+ ");
-        System.out.println("fran is logging messages! call the antivirus!");
         super(x, y, z);
     }
 }

--- a/src/main/java/io/github/fabriccommunity/everything/api/event/v4/events/OpenMenuEvent.java
+++ b/src/main/java/io/github/fabriccommunity/everything/api/event/v4/events/OpenMenuEvent.java
@@ -17,8 +17,11 @@
 
 package io.github.fabriccommunity.everything.api.event.v4.events;
 
+import com.mojang.datafixers.util.Unit;
 import io.github.fabriccommunity.everything.api.event.v4.AbstractVetoableEvent;
 import io.github.fabriccommunity.everything.api.event.v4.EventManager;
+import io.github.fabriccommunity.everything.api.functional.IO;
+import io.github.fabriccommunity.everything.api.transformer.MenuTransformer;
 import net.minecraft.container.Container;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
@@ -31,12 +34,13 @@ import java.util.Random;
  * An event that is fired when a {@link net.minecraft.container.NameableContainerFactory} is opened.
  */
 public final class OpenMenuEvent extends AbstractVetoableEvent {
-    public static final EventManager<OpenMenuEvent> MANAGER = EventManager.create();
+    public static final EventManager<OpenMenuEvent> MANAGER = EventManager.create("open-menu");
 
     private final Container menu;
     private final int syncId;
     private final Text title;
     private final ServerPlayerEntity player;
+    private MenuTransformer transformer;
 
     public OpenMenuEvent(final Container menu, final int syncId, final Text title, final ServerPlayerEntity player) {
         this.menu = menu;
@@ -71,5 +75,16 @@ public final class OpenMenuEvent extends AbstractVetoableEvent {
 
     public ServerPlayerEntity getPlayer() {
         return player;
+    }
+
+    public IO<MenuTransformer> getTransformer() {
+        return () -> transformer;
+    }
+
+    public IO<Unit> setTransformer(final MenuTransformer transformer) {
+        return () -> {
+            this.transformer = transformer;
+            return Unit.INSTANCE;
+        };
     }
 }

--- a/src/main/java/io/github/fabriccommunity/everything/api/event/v4/events/RemoveBlockEvent.java
+++ b/src/main/java/io/github/fabriccommunity/everything/api/event/v4/events/RemoveBlockEvent.java
@@ -25,7 +25,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 public final class RemoveBlockEvent extends AbstractVetoableEvent {
-    public static final EventManager<RemoveBlockEvent> MANAGER = EventManager.create();
+    public static final EventManager<RemoveBlockEvent> MANAGER = EventManager.create("remove-block");
 
     private final World world;
     private final BlockPos pos;

--- a/src/main/java/io/github/fabriccommunity/everything/api/exception/FuckException.java
+++ b/src/main/java/io/github/fabriccommunity/everything/api/exception/FuckException.java
@@ -22,12 +22,6 @@ import java.util.Random;
 
 public class FuckException extends RuntimeException {
 		public FuckException() {
-			System.out.println(" +\"\"\"\"\"+ ");
-        System.out.println("[| o o |]");
-        System.out.println(" |  ^  | ");
-        System.out.println(" | '-' | ");
-        System.out.println(" +-----+ ");
-			System.out.println("and then he turned into an NPE, funniest shit i've ever seen - fran");
 			super(Arrays.asList("Fuck", "FUCK", "FuCk", "FUUUUCK!", "FUCK!!!", "FUCKKKKKKKKK!!!").get(new Random().nextInt(5)));
 		}
 }

--- a/src/main/java/io/github/fabriccommunity/everything/api/functional/IO.java
+++ b/src/main/java/io/github/fabriccommunity/everything/api/functional/IO.java
@@ -106,8 +106,10 @@ public interface IO<A> {
      * @param other the other IO
      * @param mergingFn the merging function
      * @return the merged IO
+     * @param <B> the other type
+     * @param <C> the merged type
      */
-    default <B> IO<A> merge(final IO<B> other, final BiFunction<A, B, A> mergingFn) {
+    default <B, C> IO<C> merge(final IO<B> other, final BiFunction<A, B, C> mergingFn) {
         return () -> {
             final A first = this.execute();
             final B second = other.execute();

--- a/src/main/java/io/github/fabriccommunity/everything/mixin/TargetViolator.java
+++ b/src/main/java/io/github/fabriccommunity/everything/mixin/TargetViolator.java
@@ -21,16 +21,17 @@ public interface TargetViolator {
     /**
      * Synthetic field holding Enum#values() value
      */
-    @Accessor("field_13729")
-    public static Target[] getValues()
-    {
-        throw new IllegalStateException("Where'd my accessor go");
-    }
-    @Accessor("field_13729")
-    public static void setValues(Target[] targets)
-    {
-        throw new IllegalStateException("Where'd my accessor go");
-    }
+    // FIXME
+//    @Accessor("field_13729")
+//    public static Target[] getValues()
+//    {
+//        throw new IllegalStateException("Where'd my accessor go");
+//    }
+//    @Accessor("field_13729")
+//    public static void setValues(Target[] targets)
+//    {
+//        throw new IllegalStateException("Where'd my accessor go");
+//    }
     @Accessor("nameMap")
     public static Map<String, Target> getNameMap()
     {

--- a/src/main/java/io/github/fabriccommunity/everything/mixin/implementation/event/v4/ServerPlayerEntityMixin.java
+++ b/src/main/java/io/github/fabriccommunity/everything/mixin/implementation/event/v4/ServerPlayerEntityMixin.java
@@ -18,37 +18,40 @@
 package io.github.fabriccommunity.everything.mixin.implementation.event.v4;
 
 import com.mojang.authlib.GameProfile;
+import com.mojang.datafixers.util.Unit;
 import io.github.fabriccommunity.everything.api.elegant.scalar.ScalarOf;
 import io.github.fabriccommunity.everything.api.event.v4.events.OpenMenuEvent;
 import io.github.fabriccommunity.everything.api.functional.IO;
+import net.minecraft.container.Container;
 import net.minecraft.container.NameableContainerFactory;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.world.World;
 import org.cactoos.scalar.Ternary;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
-import java.util.OptionalInt;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(ServerPlayerEntity.class)
 abstract class ServerPlayerEntityMixin extends PlayerEntity {
     @Shadow
-    private int containerSyncId;
+    public int containerSyncId;
 
     private ServerPlayerEntityMixin(World world, GameProfile profile) {
         super(world, profile);
     }
 
-    @Inject(method = "openContainer(Lnet/minecraft/container/NameableContainerFactory;)Ljava/util/OptionalInt;", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/network/ServerPlayNetworkHandler;sendPacket(Lnet/minecraft/network/Packet;)V"), cancellable = true)
-    private void onOpenContainer(NameableContainerFactory factory, CallbackInfoReturnable<OptionalInt> info) {
-        OpenMenuEvent event = new OpenMenuEvent(container, containerSyncId, factory.getDisplayName(), (ServerPlayerEntity) (Object) this);
-        IO.executeUnsafe(OpenMenuEvent.MANAGER.execute(event).andThen(IO.of(new Ternary<>(new ScalarOf<>(event.isVetoed()), new ScalarOf<>(IO.of(() -> {
-            container = playerContainer;
-            info.setReturnValue(OptionalInt.empty());
-        })), new ScalarOf<>(IO.empty())))));
+    @Redirect(method = "openContainer(Lnet/minecraft/container/NameableContainerFactory;)Ljava/util/OptionalInt;", at = @At(value = "INVOKE", target = "Lnet/minecraft/container/NameableContainerFactory;createMenu(ILnet/minecraft/entity/player/PlayerInventory;Lnet/minecraft/entity/player/PlayerEntity;)Lnet/minecraft/container/Container;"))
+    private Container onOpenContainer(final NameableContainerFactory factory, final int syncId, final PlayerInventory inv, final PlayerEntity player) {
+        Container menu = factory.createMenu(syncId, inv, player);
+        if (menu == null) return null;
+
+        Container[] result = new Container[] { menu };
+        OpenMenuEvent event = new OpenMenuEvent(menu, containerSyncId, factory.getDisplayName(), (ServerPlayerEntity) (Object) this);
+        IO.executeUnsafe(OpenMenuEvent.MANAGER.execute(event).andThen(IO.of(new Ternary<>(new ScalarOf<>(event.isVetoed()), new ScalarOf<>(IO.of(() -> { result[0] = null; })), new ScalarOf<>(event.getTransformer().map(transformer -> { if (transformer != null) result[0] = transformer.transform((int) getX(), (int) getZ(), result[0]); return Unit.INSTANCE; }))))));
+
+        return result[0];
     }
 }


### PR DESCRIPTION
# compilation
- "Logging" before constructor super calls broke compilation in general
- The `TargetViolator` broke compilation with Gradle
# event
- It now warns you if EventManager.register was called without actually executing the registration
- Support for MenuTransformers in OpenMenuEvent
- IO.merge supports custom types as well
- OpenMenuEvent actually takes the *opened* menu instead of the player menu now
- Fixed crashes with no listeners for an event